### PR TITLE
Release management workflow

### DIFF
--- a/.github/workflows/package-release-managment.yaml
+++ b/.github/workflows/package-release-managment.yaml
@@ -1,0 +1,39 @@
+name: Create Release
+on:
+  workflow_call:
+    inputs:
+      milestone:
+        description: The milestone to tag
+        required: false
+        type: string
+      description:
+        description: Additional information to add above the changelog in the release
+        default: ""
+        required: false
+        type: string
+      branch:
+        description: The branch to tag the release on
+        default: ""
+        required: false
+        type: string
+      labels:
+        description: The labels to for the sections of the changelog
+        default: "Bug 🐞,Dependencies 📦,Feature 🏗,Enhancement ✨"
+        required: false
+        type: string
+jobs:
+  required-labels:
+    name: Required Labels
+    if: inputs.disableRequiredLabels == false && github.event_name == 'pull_request'
+    uses: ./.github/workflows/required-labels.yaml
+    with:
+      requiredLabels: ${{ inputs.labels }}
+  create-release:
+    name: Craft Release
+    if: inputs.disableRequiredLabels == false && github.event_name == 'milestone' && contains(fromJSON('["closed"]'), github.event.action)
+    uses: ./.github/workflows/package-craft-release.yaml
+    with:
+      milestone: ${{ inputs.milestone }}
+      description: ${{ inputs.description }}
+      branch: ${{ inputs.branch }}
+      labels: ${{ inputs.labels }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -17,11 +17,6 @@ on:
         default: "\\.json$"
         required: false
         type: string
-      requiredLabels:
-        description: One of the labels to be set on PR
-        default: "Bug 🐞,Dependencies 📦,Feature 🏗,Enhancement ✨"
-        required: false
-        type: string
       workingDirectory:
         description: The directory to run this workflow in
         default: ""
@@ -73,9 +68,3 @@ jobs:
     uses: ./.github/workflows/composer-diff.yaml
     with:
       workingDirectory: ${{ inputs.workingDirectory }}
-  required-labels:
-    name: Required Labels
-    if: inputs.disableRequiredLabels == false && github.event_name == 'pull_request'
-    uses: ./.github/workflows/required-labels.yaml
-    with:
-      requiredLabels: ${{ inputs.requiredLabels }}


### PR DESCRIPTION
Moved required labels from ci into this new release management workflow since it's closer there than CI itself. This will also ensure all checks run just on push and PR open events instead of on all label actions as well because that created a storm of action runs