### PR TITLE
Introduce NTS and ZTS detection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,12 +64,36 @@ jobs:
     outputs:
       version: ${{ steps.supported-versions-matrix.outputs.version }}
       upcoming: ${{ steps.supported-versions-matrix.outputs.upcoming }}
+      extensions: ${{ steps.supported-versions-matrix.outputs.extensions }}
     steps:
       - uses: actions/checkout@v3
       - id: supported-versions-matrix
         uses: WyriHaximus/github-action-composer-php-versions-in-range@v1
         with:
           upcomingReleases: true
+          working-directory: ${{ inputs.workingDirectory }}
+  supported-threading-matrix:
+    name: Supported Threading Matrix
+    runs-on: ubuntu-latest
+    needs:
+      - supported-versions-matrix
+    outputs:
+      version: ${{ steps.supported-threading-matrix.outputs.result }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: supported-threading-matrix
+        uses: actions/github-script@v7
+        env:
+          PHP_EXTENSIONS: ${{ needs.supported-versions-matrix.outputs.extensions }}
+        with:
+          script: |
+            const phpExtensions = JSON.parse(process.env.PHP_EXTENSIONS);
+            for(var i = 0; i <= phpExtensions.length; i++) {
+                if (phpExtensions[i] == 'parallel') { 
+                  return ['zts'];
+                }
+            }
+            return ['nts', 'zts'];
   supported-checks-matrix:
     name: Supported Checks Matrix
     runs-on: ubuntu-latest
@@ -86,20 +110,22 @@ jobs:
           printf "::set-output name=check::%s" $(make task-list-ci)
         working-directory: ${{ inputs.workingDirectory }}
   can-require:
-    name: Test we can require "${{ matrix.package-name }}" on PHP ${{ matrix.php }}
+    name: Test we can require "${{ matrix.package-name }}" on PHP ${{ matrix.php }} (${{ matrix.php-to-thread-or-not-to-thread }})
     strategy:
       fail-fast: false
       matrix:
         php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
+        php-to-thread-or-not-to-thread: ${{ fromJson(needs.supported-threading-matrix.outputs.version) }}
         package-name: ${{ fromJson(needs.package-name.outputs.package-name) }}
     needs:
 #      - lint-yaml
 #      - lint-json
       - package-name
       - supported-versions-matrix
+      - supported-threading-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/wyrihaximusnet/php:${{ matrix.php }}-nts-alpine-dev-root
+      image: ghcr.io/wyrihaximusnet/php:${{ matrix.php }}-${{ matrix.php-to-thread-or-not-to-thread }}-alpine-dev-root
     steps:
       - uses: actions/checkout@v3
         with:
@@ -115,11 +141,12 @@ jobs:
           composer require "${{ matrix.package-name }}:dev-${GITHUB_SHA}" --no-progress --ansi --no-interaction --prefer-dist --no-plugins -o -vvv || composer require "${{ matrix.package-name }}:dev-${GITHUB_REF_NAME}" --no-progress --ansi --no-interaction --prefer-dist --no-plugins -o -vvv
         working-directory: ${{ inputs.workingDirectory }}
   qa:
-    name: Run ${{ matrix.check }} on PHP ${{ matrix.php }} with ${{ matrix.composer }} dependency preference
+    name: Run ${{ matrix.check }} on PHP ${{ matrix.php }} (${{ matrix.php-to-thread-or-not-to-thread }}) with ${{ matrix.composer }} dependency preference
     strategy:
       fail-fast: false
       matrix:
         php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
+        php-to-thread-or-not-to-thread: ${{ fromJson(needs.supported-threading-matrix.outputs.version) }}
         composer: [lowest, locked, highest]
         check: ${{ fromJson(needs.supported-checks-matrix.outputs.check) }}
     needs:
@@ -127,9 +154,10 @@ jobs:
 #      - lint-json
       - supported-checks-matrix
       - supported-versions-matrix
+      - supported-threading-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/wyrihaximusnet/php:${{ matrix.php }}-nts-alpine-dev-root
+      image: ghcr.io/wyrihaximusnet/php:${{ matrix.php }}-${{ matrix.php-to-thread-or-not-to-thread }}-alpine-dev-root
     steps:
       - uses: actions/checkout@v3
         with:
@@ -159,20 +187,24 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
+        php-to-thread-or-not-to-thread: ${{ fromJson(needs.supported-threading-matrix.outputs.version) }}
         composer: [lowest, locked, highest]
     needs:
 #      - lint-yaml
 #      - lint-json
       - supported-checks-matrix
       - supported-versions-matrix
+      - supported-threading-matrix
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
+        env:
+          phpts: ${{ matrix.php-to-thread-or-not-to-thread }}
         with:
           php-version: ${{ matrix.php }}
           coverage: pcov
-          extensions: intl, sodium
+          extensions: ${{ join(fromJson(needs.supported-versions-matrix.outputs.extensions), ',') }}
       - uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.composer }}


### PR DESCRIPTION
This change will ensure everything is tested against NTS (non-threadsafe) and ZTS (Zend threadsafe) builds of PHP so that all packages using this workflow will be able to run on both.