### PR TITLE
Add concurrently limiting on Composer Diff

### DIFF
--- a/.github/workflows/composer-diff.yaml
+++ b/.github/workflows/composer-diff.yaml
@@ -18,6 +18,9 @@ jobs:
   comment-composer-lock-diff:
     name: Comment composer.lock diff
     runs-on: ${{ inputs.runsOn }}
+    concurrency:
+      group: ${{ inputs.runsOn }}-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - name: Comment composer.lock diff
         uses: WyriHaximus/github-action-composer.lock-diff@v2


### PR DESCRIPTION
Adding this because on GitHub hosted runners often two run at the same time leading to double comments