### PR TITLE
Revert "Switch MarkDown link checking for more performant one"

### DIFF
--- a/.github/workflows/markdown-check-links.yaml
+++ b/.github/workflows/markdown-check-links.yaml
@@ -37,4 +37,8 @@ jobs:
             ${{ inputs.workingDirectory }}/**/*.md
             ${{ inputs.markdownLinkCheckSparseCheckout }}
       - name: Check Markdown links
-        uses: becheran/mlc@v0.22.0
+        uses: umbrelladocs/action-linkspector@v1
+        with:
+          reporter: github-pr-review
+          fail_on_error: true
+#          config_file: etc/ci/markdown-link-checker.json


### PR DESCRIPTION
Reverts WyriHaximus/github-workflows#75

Reverting this because the old one works on amr64, while the new one doesn't. Will check for that in a follow up PR. Did keep the improvements from #75 in tho.