### PR TITLE
Drop Composer diff concurrency

### DIFF
--- a/.github/workflows/composer-diff.yaml
+++ b/.github/workflows/composer-diff.yaml
@@ -18,9 +18,6 @@ jobs:
   comment-composer-lock-diff:
     name: Comment composer.lock diff
     runs-on: ${{ inputs.runsOn }}
-    concurrency:
-      group: ${{ inputs.runsOn }}-${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: false
     steps:
       - name: Comment composer.lock diff
         uses: WyriHaximus/github-action-composer.lock-diff@v2


### PR DESCRIPTION
GitHub Actions was canceling later jobs instead of earlier ones resulting in failed build status